### PR TITLE
Include Django test dependency

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -654,7 +654,7 @@ class MediaIoBaseDownload(object):
             request only once.
 
     Returns:
-      (status, done): (MediaDownloadStatus, boolean)
+      (status, done): (MediaDownloadProgress, boolean)
          The value of 'done' will be True when the media has been fully
          downloaded.
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,8 @@ deps =
        mox
        pyopenssl
        pycrypto==2.6
-       django
+       django<2.0.0; python_version < '3.0.0'
+       django>=2.0.0; python_version > '3.0.0'
        webtest
        nose
        coverage>=3.6,<3.99


### PR DESCRIPTION
To include the test for Django 2.0 only supporting Python 3.0 and above